### PR TITLE
refactor(install): Avoid using write-host

### DIFF
--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -22,16 +22,9 @@
     # Note: if a rule is in both IncludeRules and ExcludeRules, the rule
     # will be excluded.
     ExcludeRules = @(
-        # Currently Scoop widely uses Write-Host to output colored text.
-        'PSAvoidUsingWriteHost',
-        # Temporarily allow uses of Invoke-Expression,
-        # this command is used by some core functions and hard to be removed.
-        'PSAvoidUsingInvokeExpression',
         # PSUseDeclaredVarsMoreThanAssignments doesn't currently work due to:
         # https://github.com/PowerShell/PSScriptAnalyzer/issues/636
         'PSUseDeclaredVarsMoreThanAssignments',
-        # Do not check functions whose verbs change system state
-        'PSUseShouldProcessForStateChangingFunctions',
         # Do not check positional parameters for scoop config command
         'PSAvoidUsingPositionalParameters'
     )

--- a/install.ps1
+++ b/install.ps1
@@ -66,7 +66,7 @@ param(
 function Write-InstallInfo {
     param(
         [Parameter(Mandatory = $True, Position = 0)]
-        $String,
+        [String] $String,
         [Parameter(Mandatory = $False, Position = 1)]
         [System.ConsoleColor] $ForegroundColor = $host.UI.RawUI.ForegroundColor
     )

--- a/install.ps1
+++ b/install.ps1
@@ -63,14 +63,33 @@ param(
     [Switch] $RunAsAdmin
 )
 
+function Write-InstallInfo {
+    param(
+        [Parameter(Mandatory = $True, Position = 0)]
+        $String,
+        [Parameter(Mandatory = $False, Position = 1)]
+        $ForegroundColor
+    )
+
+    $backup = $host.UI.RawUI.ForegroundColor
+
+    if ($ForegroundColor) {
+        $host.UI.RawUI.ForegroundColor = "$ForegroundColor"
+    }
+
+    Write-Output "$String"
+
+    $host.UI.RawUI.ForegroundColor = "$backup"
+}
+
 function Deny-Install {
     param(
         [String] $message,
         [Int] $errorCode = 1
     )
 
-    Write-Host $message -f DarkRed
-    Write-Output "Abort."
+    Write-InstallInfo -String $message -ForegroundColor DarkRed
+    Write-InstallInfo "Abort."
 
     # Don't abort if invoked with iex that would close the PS session
     if ($IS_EXECUTED_FROM_IEX) {
@@ -216,7 +235,7 @@ function Expand-ZipArchive {
             Deny-Install "Unzip failed: can't unzip because a process is locking the file."
         }
         if (Test-isFileLocked $path) {
-            Write-Output "Waiting for $path to be unlocked by another process... ($retries/10)"
+            Write-InstallInfo "Waiting for $path to be unlocked by another process... ($retries/10)"
             $retries++
             Start-Sleep -Seconds 2
         } else {
@@ -287,9 +306,9 @@ function Add-ShimsDirToPath {
 
         if (!($h -eq '\')) {
             $friendlyPath = "$SCOOP_SHIMS_DIR" -Replace ([Regex]::Escape($h)), "~\"
-            Write-Output "Adding $friendlyPath to your path."
+            Write-InstallInfo "Adding $friendlyPath to your path."
         } else {
-            Write-Output "Adding $SCOOP_SHIMS_DIR to your path."
+            Write-InstallInfo "Adding $SCOOP_SHIMS_DIR to your path."
         }
 
         # For future sessions
@@ -336,7 +355,7 @@ function Add-Config {
 }
 
 function Install-Scoop {
-    Write-Output 'Initializing...'
+    Write-InstallInfo "Initializing..."
     # Validate install parameters
     Test-ValidateParameter
     # Check prerequisites
@@ -345,7 +364,7 @@ function Install-Scoop {
     Optimize-SecurityProtocol
 
     # Download scoop zip from GitHub
-    Write-Output 'Downloading...'
+    Write-InstallInfo "Downloading..."
     $downloader = Get-Downloader
     # 1. download scoop
     $scoopZipfile = "$SCOOP_APP_DIR\scoop.zip"
@@ -361,7 +380,7 @@ function Install-Scoop {
     $downloader.downloadFile($SCOOP_MAIN_BUCKET_REPO, $scoopMainZipfile)
 
     # Extract files from downloaded zip
-    Write-Output 'Extracting...'
+    Write-InstallInfo "Extracting..."
     # 1. extract scoop
     $scoopUnzipTempDir = "$SCOOP_APP_DIR\_tmp"
     Expand-ZipArchive $scoopZipfile $scoopUnzipTempDir
@@ -378,7 +397,7 @@ function Install-Scoop {
     Remove-Item $scoopMainZipfile
 
     # Create the scoop shim
-    Write-Output 'Creating shim...'
+    Write-InstallInfo "Creating shim..."
     Import-ScoopShim
 
     # Finially ensure scoop shims is in the PATH
@@ -386,8 +405,8 @@ function Install-Scoop {
     # Setup initial configuration of Scoop
     Add-Config
 
-    Write-Host 'Scoop was installed successfully!' -f DarkGreen
-    Write-Output "Type 'scoop help' for instructions."
+    Write-InstallInfo "Scoop was installed successfully!" -ForegroundColor DarkGreen
+    Write-InstallInfo "Type 'scoop help' for instructions."
 }
 
 # Prepare variables

--- a/install.ps1
+++ b/install.ps1
@@ -68,7 +68,7 @@ function Write-InstallInfo {
         [Parameter(Mandatory = $True, Position = 0)]
         $String,
         [Parameter(Mandatory = $False, Position = 1)]
-        $ForegroundColor
+        [System.ConsoleColor] $ForegroundColor
     )
 
     $backup = $host.UI.RawUI.ForegroundColor

--- a/install.ps1
+++ b/install.ps1
@@ -68,18 +68,18 @@ function Write-InstallInfo {
         [Parameter(Mandatory = $True, Position = 0)]
         $String,
         [Parameter(Mandatory = $False, Position = 1)]
-        [System.ConsoleColor] $ForegroundColor
+        [System.ConsoleColor] $ForegroundColor = $host.UI.RawUI.ForegroundColor
     )
 
     $backup = $host.UI.RawUI.ForegroundColor
 
-    if ($ForegroundColor) {
-        $host.UI.RawUI.ForegroundColor = "$ForegroundColor"
+    if ($ForegroundColor -ne $host.UI.RawUI.ForegroundColor) {
+        $host.UI.RawUI.ForegroundColor = $ForegroundColor
     }
 
     Write-Output "$String"
 
-    $host.UI.RawUI.ForegroundColor = "$backup"
+    $host.UI.RawUI.ForegroundColor = $backup
 }
 
 function Deny-Install {

--- a/tests/Linter.Tests.ps1
+++ b/tests/Linter.Tests.ps1
@@ -30,8 +30,8 @@ Describe -Tag 'Linter' "PSScriptAnalyzer" {
                         '*.ps1'  { $type = 'Script' }
                         '*.psd1' { $type = 'Manifest' }
                     }
-                    Write-Host -f Yellow "      [*] $($result.Severity): $($result.Message)"
-                    Write-Host -f Yellow "          $($result.RuleName) in $type`: $directory\$($result.ScriptName):$($result.Line)"
+                    Write-Warning "      [*] $($result.Severity): $($result.Message)"
+                    Write-Warning "          $($result.RuleName) in $type`: $directory\$($result.ScriptName):$($result.Line)"
                 }
             }
         }

--- a/tests/bin/test.ps1
+++ b/tests/bin/test.ps1
@@ -37,7 +37,7 @@ if ($env:CI -eq $true) {
     }
 }
 
-Write-Host 'Invoke-Pester' @splat
+Write-Output 'Invoke-Pester' @splat
 $result = Invoke-Pester @splat
 
 if ($env:CI -eq $true) {


### PR DESCRIPTION
Close #7 

All outputs now go to the pipline, then users can redirect it to out-null to silence the installer.

```
.\install.ps1 [-Parameters ...] | Out-Null
```

Or they can redirect it to a log file.

```
.\install.ps1 [-Parameters ...] > install.log
```

To check the installation result, use `$LASTEXITCODE`.