### PR TITLE
Fix "The property 'Count' cannot be found on this object."

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -339,7 +339,7 @@ function Add-Config {
         [String] $Value
     )
 
-    $scoopConfig = Use-Config
+    $scoopConfig = @(Use-Config)
 
     if ($null -eq $scoopConfig -or $scoopConfig.Count -eq 0) {
         $baseDir = Split-Path -Path $SCOOP_CONFIG_FILE


### PR DESCRIPTION
Fixed #15, by applying the array sub-expression operator on the return from `Use-Config` inside `Add-Config`.