### PR TITLE
feat: Support using external git for initialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           echo "$Env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Test scoop command availability
         shell: powershell
-        run: scoop status
+        run: scoop help
   test_pwsh:
     name: PowerShell
     runs-on: windows-latest
@@ -52,4 +52,4 @@ jobs:
           echo "~\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Test scoop command availability
         shell: pwsh
-        run: scoop status
+        run: scoop help

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ jobs:
       - name: Test Scoop Installer
         shell: powershell
         run: ./test/bin/test.ps1
+      - name: Test Scoop Install command
+        shell: powershell
+        run: |
+          ./install.ps1 -RunAsAdmin
+          echo "$Env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Test scoop command availability
+        shell: powershell
+        run: scoop status
   test_pwsh:
     name: PowerShell
     runs-on: windows-latest
@@ -37,3 +45,11 @@ jobs:
       - name: Test Scoop Installer
         shell: pwsh
         run: ./test/bin/test.ps1
+      - name: Test Scoop Install command
+        shell: pwsh
+        run: |
+          ./install.ps1 -RunAsAdmin
+          echo "~\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Test scoop command availability
+        shell: pwsh
+        run: scoop status

--- a/install.ps1
+++ b/install.ps1
@@ -45,7 +45,7 @@
 .PARAMETER Proxy
     Specifies proxy to use during the installation.
 .PARAMETER ProxyCredential
-    Specifies credential for the given prxoy.
+    Specifies credential for the given proxy.
 .PARAMETER ProxyUseDefaultCredentials
     Use the credentials of the current user for the proxy server that is specified by the -Proxy parameter.
 .PARAMETER RunAsAdmin
@@ -539,15 +539,21 @@ function Install-Scoop {
     # Enable TLS 1.2
     Optimize-SecurityProtocol
 
+    # Download scoop from GitHub
+    Write-InstallInfo "Downloading ..."
+    $downloader = Get-Downloader
+
     if (Test-Command-Available('git')) {
+        if ($downloader.Proxy) {
+            #define env vars for git when behind a proxy
+            $Env:HTTP_PROXY = $downloader.Proxy.Address
+            $Env:HTTPS_PROXY = $downloader.Proxy.Address
+        }
         Write-Verbose "Cloning $SCOOP_PACKAGE_GIT_REPO to $SCOOP_APP_DIR"
         git clone $SCOOP_PACKAGE_GIT_REPO $SCOOP_APP_DIR
         Write-Verbose "Cloning $SCOOP_MAIN_BUCKET_GIT_REPO to $SCOOP_MAIN_BUCKET_DIR"
         git clone $SCOOP_MAIN_BUCKET_GIT_REPO $SCOOP_MAIN_BUCKET_DIR
     } else {
-        # Download scoop zip from GitHub
-        Write-InstallInfo "Downloading..."
-        $downloader = Get-Downloader
         # 1. download scoop
         $scoopZipfile = "$SCOOP_APP_DIR\scoop.zip"
         if (!(Test-Path $SCOOP_APP_DIR)) {

--- a/install.ps1
+++ b/install.ps1
@@ -518,6 +518,18 @@ function Add-DefaultConfig {
     Add-Config -Name 'last_update' -Value ([System.DateTime]::Now.ToString('o')) | Out-Null
 }
 
+function Test-Command-Available {
+    param (
+        [Parameter(Mandatory = $True, Position = 0)]
+        [String] $Command
+    )
+    if (Get-Command $Command -ErrorAction SilentlyContinue) {
+        return $true
+    } else {
+        return $false
+    }
+}
+
 function Install-Scoop {
     Write-InstallInfo "Initializing..."
     # Validate install parameters
@@ -527,43 +539,49 @@ function Install-Scoop {
     # Enable TLS 1.2
     Optimize-SecurityProtocol
 
-    # Download scoop zip from GitHub
-    Write-InstallInfo "Downloading..."
-    $downloader = Get-Downloader
-    # 1. download scoop
-    $scoopZipfile = "$SCOOP_APP_DIR\scoop.zip"
-    if (!(Test-Path $SCOOP_APP_DIR)) {
-        New-Item -Type Directory $SCOOP_APP_DIR | Out-Null
+    if (Test-Command-Available('git')) {
+        Write-Verbose "Cloning $SCOOP_PACKAGE_GIT_REPO to $SCOOP_APP_DIR"
+        git clone $SCOOP_PACKAGE_GIT_REPO $SCOOP_APP_DIR
+        Write-Verbose "Cloning $SCOOP_MAIN_BUCKET_GIT_REPO to $SCOOP_MAIN_BUCKET_DIR"
+        git clone $SCOOP_MAIN_BUCKET_GIT_REPO $SCOOP_MAIN_BUCKET_DIR
+    } else {
+        # Download scoop zip from GitHub
+        Write-InstallInfo "Downloading..."
+        $downloader = Get-Downloader
+        # 1. download scoop
+        $scoopZipfile = "$SCOOP_APP_DIR\scoop.zip"
+        if (!(Test-Path $SCOOP_APP_DIR)) {
+            New-Item -Type Directory $SCOOP_APP_DIR | Out-Null
+        }
+        Write-Verbose "Downloading $SCOOP_PACKAGE_REPO to $scoopZipfile"
+        $downloader.downloadFile($SCOOP_PACKAGE_REPO, $scoopZipfile)
+        # 2. download scoop main bucket
+        $scoopMainZipfile = "$SCOOP_MAIN_BUCKET_DIR\scoop-main.zip"
+        if (!(Test-Path $SCOOP_MAIN_BUCKET_DIR)) {
+            New-Item -Type Directory $SCOOP_MAIN_BUCKET_DIR | Out-Null
+        }
+        Write-Verbose "Downloading $SCOOP_MAIN_BUCKET_REPO to $scoopMainZipfile"
+        $downloader.downloadFile($SCOOP_MAIN_BUCKET_REPO, $scoopMainZipfile)
+
+        # Extract files from downloaded zip
+        Write-InstallInfo "Extracting..."
+        # 1. extract scoop
+        $scoopUnzipTempDir = "$SCOOP_APP_DIR\_tmp"
+        Write-Verbose "Extracting $scoopZipfile to $scoopUnzipTempDir"
+        Expand-ZipArchive $scoopZipfile $scoopUnzipTempDir
+        Copy-Item "$scoopUnzipTempDir\scoop-*\*" $SCOOP_APP_DIR -Recurse -Force
+        # 2. extract scoop main bucket
+        $scoopMainUnzipTempDir = "$SCOOP_MAIN_BUCKET_DIR\_tmp"
+        Write-Verbose "Extracting $scoopMainZipfile to $scoopMainUnzipTempDir"
+        Expand-ZipArchive $scoopMainZipfile $scoopMainUnzipTempDir
+        Copy-Item "$scoopMainUnzipTempDir\Main-*\*" $SCOOP_MAIN_BUCKET_DIR -Recurse -Force
+
+        # Cleanup
+        Remove-Item $scoopUnzipTempDir -Recurse -Force
+        Remove-Item $scoopZipfile
+        Remove-Item $scoopMainUnzipTempDir -Recurse -Force
+        Remove-Item $scoopMainZipfile
     }
-    Write-Verbose "Downloading $SCOOP_PACKAGE_REPO to $scoopZipfile"
-    $downloader.downloadFile($SCOOP_PACKAGE_REPO, $scoopZipfile)
-    # 2. download scoop main bucket
-    $scoopMainZipfile = "$SCOOP_MAIN_BUCKET_DIR\scoop-main.zip"
-    if (!(Test-Path $SCOOP_MAIN_BUCKET_DIR)) {
-        New-Item -Type Directory $SCOOP_MAIN_BUCKET_DIR | Out-Null
-    }
-    Write-Verbose "Downloading $SCOOP_MAIN_BUCKET_REPO to $scoopMainZipfile"
-    $downloader.downloadFile($SCOOP_MAIN_BUCKET_REPO, $scoopMainZipfile)
-
-    # Extract files from downloaded zip
-    Write-InstallInfo "Extracting..."
-    # 1. extract scoop
-    $scoopUnzipTempDir = "$SCOOP_APP_DIR\_tmp"
-    Write-Verbose "Extracting $scoopZipfile to $scoopUnzipTempDir"
-    Expand-ZipArchive $scoopZipfile $scoopUnzipTempDir
-    Copy-Item "$scoopUnzipTempDir\scoop-*\*" $SCOOP_APP_DIR -Recurse -Force
-    # 2. extract scoop main bucket
-    $scoopMainUnzipTempDir = "$SCOOP_MAIN_BUCKET_DIR\_tmp"
-    Write-Verbose "Extracting $scoopMainZipfile to $scoopMainUnzipTempDir"
-    Expand-ZipArchive $scoopMainZipfile $scoopMainUnzipTempDir
-    Copy-Item "$scoopMainUnzipTempDir\Main-*\*" $SCOOP_MAIN_BUCKET_DIR -Recurse -Force
-
-    # Cleanup
-    Remove-Item $scoopUnzipTempDir -Recurse -Force
-    Remove-Item $scoopZipfile
-    Remove-Item $scoopMainUnzipTempDir -Recurse -Force
-    Remove-Item $scoopMainZipfile
-
     # Create the scoop shim
     Import-ScoopShim
     # Finially ensure scoop shims is in the PATH
@@ -615,6 +633,9 @@ $SCOOP_CONFIG_FILE = "$SCOOP_CONFIG_HOME\scoop\config.json"
 # TODO: Use a specific version of Scoop and the main bucket
 $SCOOP_PACKAGE_REPO = "https://github.com/ScoopInstaller/Scoop/archive/master.zip"
 $SCOOP_MAIN_BUCKET_REPO = "https://github.com/ScoopInstaller/Main/archive/master.zip"
+
+$SCOOP_PACKAGE_GIT_REPO = "https://github.com/ScoopInstaller/Scoop.git"
+$SCOOP_MAIN_BUCKET_GIT_REPO = "https://github.com/ScoopInstaller/Main.git"
 
 # Quit if anything goes wrong
 $oldErrorActionPreference = $ErrorActionPreference

--- a/install.ps1
+++ b/install.ps1
@@ -518,7 +518,7 @@ function Add-DefaultConfig {
     Add-Config -Name 'last_update' -Value ([System.DateTime]::Now.ToString('o')) | Out-Null
 }
 
-function Test-Command-Available {
+function Test-CommandAvailable {
     param (
         [Parameter(Mandatory = $True, Position = 0)]
         [String] $Command
@@ -539,7 +539,7 @@ function Install-Scoop {
     Write-InstallInfo "Downloading ..."
     $downloader = Get-Downloader
 
-    if (Test-Command-Available('git')) {
+    if (Test-CommandAvailable('git')) {
         $old_https = $env:HTTPS_PROXY
         $old_http = $env:HTTP_PROXY
         try {
@@ -549,9 +549,9 @@ function Install-Scoop {
                 $Env:HTTPS_PROXY = $downloader.Proxy.Address
             }
             Write-Verbose "Cloning $SCOOP_PACKAGE_GIT_REPO to $SCOOP_APP_DIR"
-            git clone $SCOOP_PACKAGE_GIT_REPO $SCOOP_APP_DIR
+            git clone -q $SCOOP_PACKAGE_GIT_REPO $SCOOP_APP_DIR
             Write-Verbose "Cloning $SCOOP_MAIN_BUCKET_GIT_REPO to $SCOOP_MAIN_BUCKET_DIR"
-            git clone $SCOOP_MAIN_BUCKET_GIT_REPO $SCOOP_MAIN_BUCKET_DIR
+            git clone -q $SCOOP_MAIN_BUCKET_GIT_REPO $SCOOP_MAIN_BUCKET_DIR
         } catch {
             Get-Error $_
         } finally {

--- a/test/install.Tests.ps1
+++ b/test/install.Tests.ps1
@@ -1,0 +1,29 @@
+BeforeAll {
+    # Load SUT
+    $sut = (Split-Path -Leaf $PSCommandPath).Replace('.Tests.ps1', '.ps1')
+    . ".\$sut"
+}
+
+Describe 'Get-Downloader' -Tag 'Proxy' {
+    Context 'No proxy given via script parameter' {
+        It 'Returns WebClient without proxy' {
+            $NoProxy = $true
+            Test-ValidateParameter
+            (Get-Downloader).Proxy | Should -Be $null
+        }
+        It 'Returns WebClient without proxy although proxy is given' {
+            $NoProxy = $true
+            $Proxy = New-Object System.Uri('http://donotcare')
+            Test-ValidateParameter
+            (Get-Downloader).Proxy | Should -Be $null
+        }
+    }
+    Context 'Proxy given via script parameter' {
+        It 'Returns WebClient with proxy' {
+            $ProxyString = 'http://some.proxy.with.port:8080'
+            $Proxy = New-Object System.Uri($ProxyString)
+            Test-ValidateParameter
+            (Get-Downloader).Proxy.Address | Should -Be "$ProxyString/"
+        }
+    }
+}


### PR DESCRIPTION
* install.ps1 uses git for retrieval of Scoop and Main repo instead of downloading the zips.
* CI workflow runs install.ps1 and tests scoop availability after installation.