### PR TITLE
fix(perf): disable progress bar to improve Expand-Archive performance

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -254,9 +254,15 @@ function Expand-ZipArchive {
     # upstream issue: https://github.com/PowerShell/Microsoft.PowerShell.Archive/issues/98
     $oldVerbosePreference = $VerbosePreference
     $global:VerbosePreference = 'SilentlyContinue'
+
+    # Disable progress bar to gain performance
+    $oldProgressPreference = $ProgressPreference
+    $global:ProgressPreference = 'SilentlyContinue'
+
     # PowerShell 5+: use Expand-Archive to extract zip files
     Microsoft.PowerShell.Archive\Expand-Archive -Path $path -DestinationPath $to -Force
     $global:VerbosePreference = $oldVerbosePreference
+    $global:ProgressPreference = $oldProgressPreference
 }
 
 function Out-UTF8File {


### PR DESCRIPTION
The progress bar in powershell slows down `Expand-Archive`. 
Disabling it reduces the installation time from ~1m to around <10sec. (Windows Sandbox, 1Gbits Internet speed)

Before:
![with-progress](https://user-images.githubusercontent.com/432127/219900148-94e3cc6e-1ef0-45e8-84d4-547403815582.gif)

After:
![without-progress](https://user-images.githubusercontent.com/432127/219900153-56cc50bc-e5d1-4c53-93e8-f9c75129d85e.gif)
