### PR TITLE
fix(install): Allow installation in Windows Sandbox without -RunAsAdmin

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -118,7 +118,7 @@ function Test-ValidateParameter {
 function Test-IsAdministrator {
     return ([Security.Principal.WindowsPrincipal]`
             [Security.Principal.WindowsIdentity]::GetCurrent()`
-    ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator) -and $env:USERNAME -ne 'WDAGUtilityAccount'
 }
 
 function Test-Prerequisite {


### PR DESCRIPTION
This allows running default command `irm get.scoop.sh | iex` in Windows Sandbox instead of the modified command `iex "& {$(irm get.scoop.sh)} -RunAsAdmin"`