### PR TITLE
fix(install-env): Avoid automatic expansion of `%%` in env

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -376,7 +376,7 @@ function Get-Env {
     $EnvRegisterKey.GetValue($name, $null, $RegistryValueOption)
 }
 
-function Set-Env {
+function Put-Env {
     param(
         [String] $name,
         [String] $val,
@@ -422,7 +422,7 @@ function Add-ShimsDirToPath {
         }
 
         # For future sessions
-        Set-Env 'PATH' "$SCOOP_SHIMS_DIR;$userEnvPath"
+        Put-Env 'PATH' "$SCOOP_SHIMS_DIR;$userEnvPath"
         # For current session
         $env:PATH = "$SCOOP_SHIMS_DIR;$env:PATH"
     }

--- a/install.ps1
+++ b/install.ps1
@@ -376,7 +376,7 @@ function Get-Env {
     $EnvRegisterKey.GetValue($name, $null, $RegistryValueOption)
 }
 
-function Put-Env {
+function Write-Env {
     param(
         [String] $name,
         [String] $val,
@@ -422,7 +422,7 @@ function Add-ShimsDirToPath {
         }
 
         # For future sessions
-        Put-Env 'PATH' "$SCOOP_SHIMS_DIR;$userEnvPath"
+        Write-Env 'PATH' "$SCOOP_SHIMS_DIR;$userEnvPath"
         # For current session
         $env:PATH = "$SCOOP_SHIMS_DIR;$env:PATH"
     }


### PR DESCRIPTION
Use a method of obtaining environment variables that does not expand `%%`, while maintaining the original type of environment variables, such as `REG_EXPAND_SZ`, `REG_SZ`.

Same issue related to ScoopInstaller/Scoop#5394
Some important content in ScoopInstaller/Scoop#5395