### PR TITLE
fix(install-env): Apply env immediately by `SendMessageTimeout`

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -397,7 +397,7 @@ public static extern IntPtr SendMessageTimeout(
         2,
         5000,
         [ref] $result
-    )
+    ) | Out-Null
 }
 
 function Write-Env {

--- a/install.ps1
+++ b/install.ps1
@@ -386,8 +386,8 @@ public static extern IntPtr SendMessageTimeout(
 "@
     }
 
-    $HWND_BROADCAST = [IntPtr] 0xffff;
-    $WM_SETTINGCHANGE = 0x1a;
+    $HWND_BROADCAST = [IntPtr] 0xffff
+    $WM_SETTINGCHANGE = 0x1a
     $result = [UIntPtr]::Zero
 
     [Win32.Nativemethods]::SendMessageTimeout($HWND_BROADCAST,
@@ -425,8 +425,8 @@ function Write-Env {
             [Microsoft.Win32.RegistryValueKind]::String
         }
         $EnvRegisterKey.SetValue($name, $val, $RegistryValueKind)
-        Publish-Env
     }
+    Publish-Env
 }
 
 function Add-ShimsDirToPath {

--- a/install.ps1
+++ b/install.ps1
@@ -376,6 +376,30 @@ function Get-Env {
     $EnvRegisterKey.GetValue($name, $null, $RegistryValueOption)
 }
 
+function Publish-Env {
+    if (-not ("Win32.NativeMethods" -as [Type])) {
+        Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition @"
+[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+public static extern IntPtr SendMessageTimeout(
+    IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam,
+    uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);
+"@
+    }
+
+    $HWND_BROADCAST = [IntPtr] 0xffff;
+    $WM_SETTINGCHANGE = 0x1a;
+    $result = [UIntPtr]::Zero
+
+    [Win32.Nativemethods]::SendMessageTimeout($HWND_BROADCAST,
+        $WM_SETTINGCHANGE,
+        [UIntPtr]::Zero,
+        "Environment",
+        2,
+        5000,
+        [ref] $result
+    )
+}
+
 function Write-Env {
     param(
         [String] $name,
@@ -401,6 +425,7 @@ function Write-Env {
             [Microsoft.Win32.RegistryValueKind]::String
         }
         $EnvRegisterKey.SetValue($name, $val, $RegistryValueKind)
+        Publish-Env
     }
 }
 


### PR DESCRIPTION
Fix the problem mentioned in #48, #46, #45 mainly casued by #44.

Thanks to @chawyehsu and @r15ch13 for the information.
The information mentioned in [PowerShell/PowerShell#16989#issuecomment-1364615686](https://github.com/PowerShell/PowerShell/issues/16989#issuecomment-1364615686) is very useful, especially the last link.

[Add directory to Environment PATH variable](https://mnaoumov.wordpress.com/2012/07/24/powershell-add-directory-to-environment-path-variable/) shows a method to apply env immediately, almost the same code as used in [chocolatey/choco Fix: Env var changes may require reboot](https://github.com/chocolatey/choco/commit/a238223badb002ad824602c4f0204595192ca355).

I tested the new code in several virtual machines. The env can be updated normally outside the executing process. And because the installation script will get a new env for the current session, there is no problem in using it in the current session.

However, there is no way to get it to work when using in a Windows Terminal new tab, like chawyehsu said. But restarting a Windows Terminal can solve it.