### PR TITLE
Add OfflineSourceFolder parameter for offline installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,22 @@ irm get.scoop.sh -outfile 'install.ps1'
 iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
 ```
 
+#### Offline installation
+
+By default, the installer will download content from the official Scoop Git repos.
+For a full offline installation you can pre-download the following files:
+
+- https://github.com/ScoopInstaller/Scoop/archive/master.zip as `ScoopInstaller-Scoop.zip`
+- https://github.com/ScoopInstaller/Main/archive/master.zip as `ScoopInstaller-Main.zip`
+
+And then run:
+
+```shell
+.\install.ps1 -OfflineSourceFolder 'C:\folder\with\zip\files'
+```
+
+The installer will copy/extract the provided files as needed. They are not deleted afterwards.
+
 ### Silent Installation
 
 You can redirect all outputs to Out-Null or a log file to silence the installer. And you can use `$LASTEXITCODE` to check the installation result, it will be `0` when the installation success.

--- a/README.md
+++ b/README.md
@@ -75,10 +75,14 @@ For a full offline installation you can pre-download the following files:
 And then run:
 
 ```shell
-.\install.ps1 -OfflineSourceFolder 'C:\folder\with\zip\files'
+# From a local folder
+.\install.ps1 -OfflineSourceFolder 'C:\Local\Path\To\Zip\Files'
+
+# From a network path
+.\install.ps1 -OfflineSourceFolder '\\UNC\Path\To\Zip\Files'
 ```
 
-The installer will copy/extract the provided files as needed. They are not deleted afterwards.
+The installer will copy/extract the provided ZIP files as needed. They are not deleted afterwards.
 
 ### Silent Installation
 

--- a/install.ps1
+++ b/install.ps1
@@ -50,6 +50,8 @@
     Use the credentials of the current user for the proxy server that is specified by the -Proxy parameter.
 .PARAMETER RunAsAdmin
     Force to run the installer as administrator.
+.PARAMETER OfflineSourceFolder
+    Folder containing the 2 installer ZIP files for offline installation.
 .LINK
     https://scoop.sh
 .LINK
@@ -63,7 +65,8 @@ param(
     [Uri] $Proxy,
     [System.Management.Automation.PSCredential] $ProxyCredential,
     [Switch] $ProxyUseDefaultCredentials,
-    [Switch] $RunAsAdmin
+    [Switch] $RunAsAdmin,
+    [String] $OfflineSourceFolder
 )
 
 # Disable StrictMode in this script
@@ -569,7 +572,7 @@ function Install-Scoop {
     $downloader = Get-Downloader
     [bool]$downloadZipsRequired = $True
 
-    if (Test-CommandAvailable('git')) {
+    if ((Test-CommandAvailable('git')) -and ($OfflineSourceFolder -eq "") ) {
         $old_https = $env:HTTPS_PROXY
         $old_http = $env:HTTP_PROXY
         try {
@@ -604,15 +607,26 @@ function Install-Scoop {
         if (!(Test-Path $SCOOP_APP_DIR)) {
             New-Item -Type Directory $SCOOP_APP_DIR | Out-Null
         }
-        Write-Verbose "Downloading $SCOOP_PACKAGE_REPO to $scoopZipfile"
-        $downloader.downloadFile($SCOOP_PACKAGE_REPO, $scoopZipfile)
+        if ($OfflineSourceFolder -eq "") {
+            Write-Verbose "Downloading $SCOOP_PACKAGE_REPO to $scoopZipfile"
+            $downloader.downloadFile($SCOOP_PACKAGE_REPO, $scoopZipfile)
+        } else {
+            Write-Verbose "Copying $OfflineSourceFolder\$SCOOP_PACKAGE_OFFLINE_FILENAME to $scoopZipfile"
+            Copy-Item "$OfflineSourceFolder\$SCOOP_PACKAGE_OFFLINE_FILENAME" $scoopZipfile
+        }
+
         # 2. download scoop main bucket
         $scoopMainZipfile = "$SCOOP_MAIN_BUCKET_DIR\scoop-main.zip"
         if (!(Test-Path $SCOOP_MAIN_BUCKET_DIR)) {
             New-Item -Type Directory $SCOOP_MAIN_BUCKET_DIR | Out-Null
         }
-        Write-Verbose "Downloading $SCOOP_MAIN_BUCKET_REPO to $scoopMainZipfile"
-        $downloader.downloadFile($SCOOP_MAIN_BUCKET_REPO, $scoopMainZipfile)
+        if ($OfflineSourceFolder -eq "") {
+            Write-Verbose "Downloading $SCOOP_MAIN_BUCKET_REPO to $scoopMainZipfile"
+            $downloader.downloadFile($SCOOP_MAIN_BUCKET_REPO, $scoopMainZipfile)
+        } else {
+            Write-Verbose "Copying $OfflineSourceFolder\$SCOOP_MAIN_BUCKET_OFFLINE_FILENAME to $scoopMainZipfile"
+            Copy-Item "$OfflineSourceFolder\$SCOOP_MAIN_BUCKET_OFFLINE_FILENAME" $scoopMainZipfile
+        }
 
         # Extract files from downloaded zip
         Write-InstallInfo 'Extracting...'
@@ -687,6 +701,10 @@ $SCOOP_MAIN_BUCKET_REPO = 'https://github.com/ScoopInstaller/Main/archive/master
 
 $SCOOP_PACKAGE_GIT_REPO = 'https://github.com/ScoopInstaller/Scoop.git'
 $SCOOP_MAIN_BUCKET_GIT_REPO = 'https://github.com/ScoopInstaller/Main.git'
+
+# Expected filenames for the Git repo contents when performing an offline install
+$SCOOP_PACKAGE_OFFLINE_FILENAME = 'ScoopInstaller-Scoop.zip'
+$SCOOP_MAIN_BUCKET_OFFLINE_FILENAME = 'ScoopInstaller-Main.zip'
 
 # Quit if anything goes wrong
 $oldErrorActionPreference = $ErrorActionPreference


### PR DESCRIPTION
This pull-requests implements an offline installation for Scoop.
I documented the usage in the updated README.

1. Pre-download the following files into a folder of your choice

https://github.com/ScoopInstaller/Scoop/archive/master.zip as `ScoopInstaller-Scoop.zip`
https://github.com/ScoopInstaller/Main/archive/master.zip as `ScoopInstaller-Main.zip`

2. Later, run

```shell
# From a local folder
.\install.ps1 -OfflineSourceFolder 'C:\Local\Path\To\Zip\Files'

# From a network path
.\install.ps1 -OfflineSourceFolder '\\UNC\Path\To\Zip\Files'
```

The files are not deleted, which means they can be re-used for other installations.
This should address https://github.com/ScoopInstaller/Scoop/issues/3505.
