### PR TITLE
fix: normalize Scoop directory variables by trimming trailing backslash

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -682,11 +682,11 @@ $IS_EXECUTED_FROM_IEX = ($null -eq $MyInvocation.MyCommand.Path)
 Test-LanguageMode
 
 # Scoop root directory
-$SCOOP_DIR = $ScoopDir, $env:SCOOP, "$env:USERPROFILE\scoop" | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
+$SCOOP_DIR = ($ScoopDir, $env:SCOOP, "$env:USERPROFILE\scoop" | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1).TrimEnd('\')
 # Scoop global apps directory
-$SCOOP_GLOBAL_DIR = $ScoopGlobalDir, $env:SCOOP_GLOBAL, "$env:ProgramData\scoop" | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
+$SCOOP_GLOBAL_DIR = ($ScoopGlobalDir, $env:SCOOP_GLOBAL, "$env:ProgramData\scoop" | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1).TrimEnd('\')
 # Scoop cache directory
-$SCOOP_CACHE_DIR = $ScoopCacheDir, $env:SCOOP_CACHE, "$SCOOP_DIR\cache" | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1
+$SCOOP_CACHE_DIR = ($ScoopCacheDir, $env:SCOOP_CACHE, "$SCOOP_DIR\cache" | Where-Object { -not [String]::IsNullOrEmpty($_) } | Select-Object -First 1).TrimEnd('\')
 # Scoop shims directory
 $SCOOP_SHIMS_DIR = "$SCOOP_DIR\shims"
 # Scoop itself directory


### PR DESCRIPTION
Resolve the issue mentioned in  https://github.com/ScoopInstaller/Extras/issues/16044.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposes standardized variables for app, main bucket, and config locations, including config home and config file paths.
* **Bug Fixes**
  * Normalizes key directory paths by removing trailing backslashes, improving reliability across installations.
* **Refactor**
  * Centralizes path handling into shared variables for consistent behavior and easier configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->