### PR TITLE
feat: use portable config

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -694,8 +694,10 @@ $SCOOP_APP_DIR = "$SCOOP_DIR\apps\scoop\current"
 # Scoop main bucket directory
 $SCOOP_MAIN_BUCKET_DIR = "$SCOOP_DIR\buckets\main"
 # Scoop config file location
-$SCOOP_CONFIG_HOME = $env:XDG_CONFIG_HOME, "$env:USERPROFILE\.config" | Select-Object -First 1
-$SCOOP_CONFIG_FILE = "$SCOOP_CONFIG_HOME\scoop\config.json"
+# $SCOOP_CONFIG_HOME = $env:XDG_CONFIG_HOME, "$env:USERPROFILE\.config" | Select-Object -First 1
+# $SCOOP_CONFIG_FILE = "$SCOOP_CONFIG_HOME\scoop\config.json"
+$SCOOP_CONFIG_HOME = $SCOOP_DIR
+$SCOOP_CONFIG_FILE = "$SCOOP_DIR\config.json"
 
 # TODO: Use a specific version of Scoop and the main bucket
 $SCOOP_PACKAGE_REPO = 'https://github.com/ScoopInstaller/Scoop/archive/master.zip'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer can clone core resources from Git repositories, falling back to ZIP downloads if cloning fails.
  * New options exposed to point the installer at Git-based package and bucket sources.

* **Changed**
  * Configuration now resides under the installation directory by default (config file path updated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->