### PR TITLE
feat!: default config file location to scoop root directory

### DIFF
--- a/.github/scripts/e2e-test.ps1
+++ b/.github/scripts/e2e-test.ps1
@@ -6,22 +6,34 @@ if ($env:CI -ne $true -or $env:GITHUB_ACTIONS -ne $true) {
     throw 'This script is intended to be run in GitHub Actions CI environment only'
 }
 
-Write-Output "$Env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 $WorkingRoot = "$PSScriptRoot\..\.."
 
 # Typical installation
+Write-Output '# Testing typical installation'
 & "$WorkingRoot\install.ps1"
-if (-not (Test-Path -Path "$Env:USERPROFILE\.config\scoop\config.json")) {
+Write-Output "$Env:USERPROFILE\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+$configFilePath = "$Env:USERPROFILE\scoop\config.json"
+if (-not (Test-Path -Path $configFilePath)) {
     throw 'Scoop config file should exist after installation'
 }
 scoop help
+scoop config use_sqlite_cache true
+Write-Output "Config file: $configFilePath"
+Get-Content -Raw -Path $configFilePath | Write-Output
 Remove-Item -Path "$Env:USERPROFILE\scoop" -Recurse -Force -ErrorAction SilentlyContinue
 
 # Fall back to download zips when git not available
 git config --global protocol.https.allow never
 # Custom installation directory
 $CustomScoopDir = "$Env:USERPROFILE\custom_scoop"
+$env:XDG_CONFIG_HOME = "$Env:USERPROFILE\.config"
+Write-Output '# Testing installation with custom directory and XDG_CONFIG_HOME set'
 & "$WorkingRoot\install.ps1" -ScoopDir $CustomScoopDir
 Write-Output "$CustomScoopDir\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+$configFilePath = "$env:XDG_CONFIG_HOME\scoop\config.json"
+if (-not (Test-Path -Path $configFilePath)) {
+    throw 'Scoop config file should exist after installation (XDG)'
+}
 scoop help
-Get-Content -Raw -Path "$env:USERPROFILE\.config\scoop\config.json" | Write-Output
+Write-Output "Config file: $configFilePath"
+Get-Content -Raw -Path $configFilePath | Write-Output

--- a/install.ps1
+++ b/install.ps1
@@ -699,8 +699,8 @@ $SCOOP_APP_DIR = "$SCOOP_DIR\apps\scoop\current"
 # Scoop main bucket directory
 $SCOOP_MAIN_BUCKET_DIR = "$SCOOP_DIR\buckets\main"
 # Scoop config file location
-$SCOOP_CONFIG_HOME = $env:XDG_CONFIG_HOME, "$env:USERPROFILE\.config" | Select-Object -First 1
-$SCOOP_CONFIG_FILE = "$SCOOP_CONFIG_HOME\scoop\config.json"
+$SCOOP_CONFIG_HOME = if ($env:XDG_CONFIG_HOME) { "$env:XDG_CONFIG_HOME\scoop" } else { "$SCOOP_DIR" }
+$SCOOP_CONFIG_FILE = "$SCOOP_CONFIG_HOME\config.json"
 
 # TODO: Use a specific version of Scoop and the main bucket
 $SCOOP_PACKAGE_REPO = 'https://github.com/ScoopInstaller/Scoop/archive/master.zip'


### PR DESCRIPTION
Close #119 
Close #126 
Close https://github.com/ScoopInstaller/Scoop/pull/6600

**NOTICE**: This would be a **breaking change** considering downstream projects might expect the config file to be located in `~\.config\scoop\config.json` by default. We could introduce a flag (`-Portable`) to support such feature, however a hard breaking change is inevitable to make the switch of default location.